### PR TITLE
fix(api1:createUser): mysql INSERT statement

### DIFF
--- a/vapi/api1/createUser.php
+++ b/vapi/api1/createUser.php
@@ -34,7 +34,7 @@ if(validateAll()){
     $course=mysqli_real_escape_string($dbconn,$course);
     $password=mysqli_real_escape_string($dbconn,$password);
 
-    $query="INSERT into api1users values('','$username','$name','$course','$password')";
+    $query="INSERT into api1users (username, name, course, password) values ('$username','$name','$course','$password')";
 
     if(mysqli_query($dbconn,$query)){
         $latest_id=mysqli_insert_id($dbconn);


### PR DESCRIPTION
Hi,
Following docker setup instructions as per the README, without a custom MySQL configuration file, I was not being able to create new users:

```json
{
  "status": 400,
  "userCreated": "false",
  "cause": "dbInsertionFailed"
}
```

This PR should fix it.

Cheers,
Paulo A. Silva