### PR TITLE
fix(api5:createUser): MySQL INSERT statement

### DIFF
--- a/vapi/api5/createUser.php
+++ b/vapi/api5/createUser.php
@@ -40,7 +40,7 @@ if(validateAll()){
     $mobileno=mysqli_real_escape_string($dbconn,$mobileno);
 
 
-    $query="INSERT into api5users values('','$username','$password','$name','$address','$mobileno')";
+    $query="INSERT into api5users (username, password, name, address, mobileno) values ('$username','$password','$name','$address','$mobileno')";
 
     if(mysqli_query($dbconn,$query)){
         $latest_id=mysqli_insert_id($dbconn);


### PR DESCRIPTION
Without custom MySQL configuration '' is not a valid value for
api5_users table attribute/column.

Instead of relying on positional columns/values, adding column names to
the INSERT statement solves the issue.