### PR TITLE
Fix api2/user/login

### DIFF
--- a/vapi/app/Http/Controllers/API2UsersController.php
+++ b/vapi/app/Http/Controllers/API2UsersController.php
@@ -10,8 +10,8 @@ class API2UsersController extends Controller
     public function login(Request $request)
     {
 
-        $user=API2Users::where('email',$request->input('email'))
-            ->where('password',$request->input('password'))->first();
+        $post_data = json_decode($request->getContent());
+        $user = API2Users::where('email',$post_data->{'email'})->where('password',$post_data->{'password'})->first();
 
         if($user)
         {


### PR DESCRIPTION
There is a discrepancy between postman docs that specify JSON payload and the current implementation that uses x-www-form-urlencoded. This pull request fixes this issue.

Currently this is possible:

```bash
curl http://localhost/vapi/api2/user/login -X POST -d 'email=savanna48@ortiz.com&password=zTyBwV/9'
# {"success":"true","token":"REDACTED"}
```

But the postman docs says the payload should be a JSON:

```json
{
    "email":"",
    "password":""
}
```

After my change, the application accepts the JSON payload.

```bash
curl http://localhost/vapi/api2/user/login -X POST -H 'Content-Type: application/json' -d '{"email": "savanna48@ortiz.com", "password": "zTyBwV/9"}' -v
# {"success":"true","token":"REDACTED"}
```