### PR TITLE
Add secret to helm chart, tagging adjustments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.27-apache 
+FROM php:7.4-apache 
 RUN docker-php-ext-install mysqli pdo_mysql
 RUN apt-get update \
     && apt-get install -y libzip-dev \

--- a/vapi-chart/templates/secret.yaml
+++ b/vapi-chart/templates/secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "vapi.fullname" . }}
+data:
+  username: {{ .Values.mysql.auth.username | b64enc }}
+  password: {{ .Values.mysql.auth.password | b64enc }}

--- a/vapi-chart/templates/secret.yaml
+++ b/vapi-chart/templates/secret.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   username: {{ .Values.mysql.auth.username | b64enc }}
   password: {{ .Values.mysql.auth.password | b64enc }}
+  

--- a/vapi-chart/values.yaml
+++ b/vapi-chart/values.yaml
@@ -154,7 +154,7 @@ mysql:
   image:
     registry: docker.io
     repository: bitnami/mysql
-    tag: 8.0.28-debian-10-r0
+    tag: 8.0
     debug: true
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/vapi-chart/values.yaml
+++ b/vapi-chart/values.yaml
@@ -189,10 +189,10 @@ mysql:
     ## @param auth.username Name for a custom user to create
     ## ref: https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-user-on-first-run
     ##
-    # username: $MYSQL_USERNAME
+    username: "vapi_user"
     ## @param auth.password Password for the new user. Ignored if existing secret is provided
     ##
-    # password: $MYSQL_PASSWORD
+    password: "vapipass"
     ## @param auth.replicationUser MySQL replication user
     ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-up-a-replication-cluster
     ##


### PR DESCRIPTION
This should resolve #39 The secret is now added and tagging was adjusted for images to pull in the latest fixpacks for the minor version of mysql and php image in the Dockerfile. 
