### PR TITLE
Change www service port map to 8000:80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     www:
         build: .
         ports: 
-            - "80:80"
+            - "8000:80"
         volumes:
             - ./vapi:/var/www/html/vapi
         links:


### PR DESCRIPTION
This is to avoid possible conflicts with services that are running on the container host on port 80, such as an NGINX proxy etc. Generally it's a good idea to avoid mapping to low host ports.