### PR TITLE
Change Phpmyadmin image link

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
         networks:
             - default
     phpmyadmin:
-        image: phpmyadmin/phpmyadmin
+        image: phpmyadmin:latest
         links: 
             - db:db
         ports:


### PR DESCRIPTION
the new phymyadmin goes to the proper image. 
This is needed, as the "old" one, did not have arm64 architecture available.

Check the discussion here:
https://github.com/phpmyadmin/phpmyadmin/issues/17460 And especially here:
https://github.com/phpmyadmin/phpmyadmin/issues/17460#issuecomment-1079808360