### PR TITLE
Change exposed port to non-privileged

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     www:
         build: .
         ports: 
-            - "80:80"
+            - "8080:80"
         volumes:
             - ./vapi:/var/www/html/vapi
         links:


### PR DESCRIPTION
Change the exposed port to non-privileged, in case you have a docker/OCI setup with limited privileges. This is the case for podman rootless containers:
https://github.com/containers/podman/blob/main/rootless.md

So in an easy scenario, the best would be to use ports highter then 1024 in general when binding ports in docker.

This is opinionated, of course.