### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
           MIX_PUSHER_APP_KEY: "${PUSHER_APP_KEY}"
           MIX_PUSHER_APP_CLUSTER: "${PUSHER_APP_CLUSTER}"
     db:
-        image: mysql:8.0
+        image: mysql:8
         ports: 
             - "3306:3306"
         command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
The official docker image, displayed here: https://hub.docker.com/_/mysql/

If you use 8.0 as the tag, then the latest version is 8.0.40. However, for Major version 8, the latest is 8.4.3. So it would be best to use :8 as the image tag, instead of :8.0