### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![PHP](https://img.shields.io/badge/php-7.3^-yellow)](https://github.com/roottusk/vapi)
 [![Laravel](https://img.shields.io/badge/Laravel-8-orange)](https://github.com/roottusk/vapi)
 [![Issues](https://img.shields.io/github/issues-closed/roottusk/vapi?color=%23eb3434)](https://github.com/roottusk/vapi/issues)
+
 <p align="center">
 <img src="vapi_logo.png" >
 </p>
 
 vAPI is Vulnerable Adversely Programmed Interface which is Self-Hostable API that mimics OWASP API Top 10 scenarios in the means of Exercises. 
-
 
 # Requirements
 
@@ -44,7 +44,6 @@ git clone https://github.com/roottusk/vapi.git
 Import `vapi.sql` into MySQL Database
 
 Configure the DB Credentials in the `vapi/.env`
-
 
 ## Starting MySQL service
 
@@ -79,6 +78,19 @@ Browse `http://localhost/vapi/` for Documentation
 
 After Sending requests, refer to the Postman Tests or Environment for Generated Tokens
 
+## Authorization
+
+The `Authorization-Token` is a base64 encoded result of the username and password combined in the following format: `username:password`
+
+**Example:**
+- Username: `foo`
+- Password: `foo`
+- Combined: `foo:foo`
+- Base64 Encoded: `Zm9vOmZvbw==`
+- Authorization-Token Header: `Zm9vOmZvbw==`
+
+Use this token in the `Authorization-Token` header when making API requests.
+
 # Deployment
 
 [Helm](https://helm.sh/) can be used to deploy to a Kubernetes namespace. The chart is in the `vapi-chart` folder. The chart requires one secret named `vapi` with the following values:
@@ -95,6 +107,7 @@ Sample Helm Install Command: `helm upgrade --install vapi ./vapi-chart --values=
 The MYSQL_ROOT_PASSWORD on line 232 in the `values.yaml` must match that on line 184 in order to work. 
 
 # Presented At
+
 [OWASP 20th Anniversary](https://owasp20thanniversaryevent20.sched.com/event/ll1k)
 
 [Blackhat Europe 2021 Arsenal](https://www.youtube.com/watch?v=7_Q5Rlm7Too)
@@ -103,12 +116,12 @@ The MYSQL_ROOT_PASSWORD on line 232 in the `values.yaml` must match that on line
 
 [@Hack, Riyadh, KSA](https://athack.com/speakers?keys=Tushar)
 
-
 # Upcoming
 
 [APISecure.co](https://apisecure.co/)
 
 # Mentions and References
+
 [1] https://apisecurity.io/issue-132-experian-api-leak-breaches-digitalocean-geico-burp-plugins-vapi-lab/
 
 [2] https://dsopas.github.io/MindAPI/references/
@@ -134,4 +147,3 @@ The MYSQL_ROOT_PASSWORD on line 232 in the `values.yaml` must match that on line
 # Acknowledgements
 
 * The icon and banner uses image from [Flaticon](https://www.flaticon.com/free-icon/bug_190835)
-


### PR DESCRIPTION
# Documentation Update: Authorization Token Clarification
 
In the context

**docs: Add proper Authorization-Token documentation in README**

With this update, the authenticity factor of the API authentication has been improved with clearer documentation on the usage of the Authorization-Token.

**Changes
- Introduced a "Authorization" section for Usage
- Recorded the base64 encoding format: `username:password` – Offered an example with sample credentials

- Added information on using the token in API requests Rationale
- Makes it easier for new users to understand the base64 authentication process
- Acts as example with easy accessibility

- Enhances onboarding processes and decreases customer inquiries
- Makes the process of authentication clear **EXAMPLE PROVIDED:**

Username: foo

Password: foo To enable base64 decoding, ```
UCT This way, users easily create the right Authorization Tokens without the need for guesswork.